### PR TITLE
Fix build error: MAP_HUGE_2MB could not be defined

### DIFF
--- a/test/util.h
+++ b/test/util.h
@@ -3,6 +3,9 @@
 #include "type.h"
 #include "new_func.h"
 
+#if !defined(MAP_HUGE_2MB)
+#define MAP_HUGE_2MB (21 << MAP_HUGE_SHIFT)
+#endif
 
 inline index_t upper_power_of_two(index_t v)
 {


### PR DESCRIPTION
On my linux box, Linux Arch v5.0.13, this macro is not defined even from <sys/mman.h>. This patch redefines it in case it's missing. 